### PR TITLE
Updated URLs to use HTTPS where possible

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>kangax projects</title>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet'>
     <style>
       body { font-family: "Open Sans", sans-serif; color: #aaa; }
       ul { padding-left: 1.5em; }
@@ -36,7 +36,7 @@
         <span class="year current" title="year">2014-current</span>
       </li>
       <li>
-        <a href="http://kangax.github.io/es5-compat-table/es6">ECMAScript 6 compatibility table</a>
+        <a href="http://kangax.github.io/compat-table/es6/">ECMAScript 6 compatibility table</a>
         <span class="year current" title="year">2012-current</span>
       </li>
       <li>
@@ -45,7 +45,7 @@
         <span class="year current" title="year">2010-current</span>
       </li>
       <li>
-        <a href="http://kangax.github.io/jstests">Various tests (Javascript, HTML, etc.)</a>
+        <a href="https://kangax.github.io/jstests/">Various tests (Javascript, HTML, etc.)</a>
         <span class="year current" title="year">2009-current</span>
       </li>
       <li>
@@ -53,20 +53,20 @@
         <span class="year current" title="year">2008-current</span>
       </li>
       <li>
-        <a href="http://kangax.github.io/es5-compat-table">ECMAScript 5 compatibility table</a>
+        <a href="http://kangax.github.io/compat-table/es5/">ECMAScript 5 compatibility table</a>
         (
-        <a href="http://kangax.github.io/es5-compat-table/non-standard">non-standard</a>,
-        <a href="http://kangax.github.io/es5-compat-table/strict-mode/">strict mode</a>
+        <a href="http://kangax.github.io/compat-table/non-standard/">non-standard</a>,
+        <a href="http://kangax.github.io/compat-table/es5/#test-Strict_mode">strict mode</a>
         )
         <span class="year current" title="year">2010-current</span>
       </li>
       <li>
-        <a href="http://kangax.github.io/html-minifier">HTML minifier</a>
-        (<a href="http://kangax.github.io/html-minifier/tests">tests</a> )
+        <a href="https://kangax.github.io/html-minifier/">HTML minifier</a>
+        (<a href="https://kangax.github.io/html-minifier/tests/">tests</a> )
         <span class="year current" title="year">2010-current</span>
       </li>
       <li>
-        <a href="http://kangax.github.io/es5-testsuite/">ECMAScript 5 official test suite (web-ported, runs immediately!)</a>
+        <a href="https://kangax.github.io/es5-testsuite/">ECMAScript 5 official test suite (web-ported, runs immediately!)</a>
         <span class="year year-2010" title="year">2010</span>
       </li>
       <li>
@@ -74,31 +74,31 @@
         <span class="year year-2009" title="year">2009</span>
       </li>
       <li>
-        <a href="http://kangax.github.io/nfe">Named function expressions demystified (article)</a>
+        <a href="https://kangax.github.io/nfe/">Named function expressions demystified (article)</a>
         <span class="year year-2009" title="year">2009</span>
       </li>
       <li>
-        <a href="http://kangax.github.io/sputniktests-webrunner/">Sputniktests (ECMAScript 3 test suite) web runner</a>
+        <a href="https://kangax.github.io/sputniktests-webrunner/">Sputniktests (ECMAScript 3 test suite) web runner</a>
         <span class="year year-2009" title="year">2009</span>
       </li>
       <li>
-        <a href="http://kangax.github.io/domlint/">DOM Lint</a>
+        <a href="https://kangax.github.io/domlint/">DOM Lint</a>
         <span class="year year-2009" title="year">2009</span>
       </li>
       <li>
-        <a href="http://kangax.github.io/js-checker">Environment checker</a>
+        <a href="https://kangax.github.io/js-checker/">Environment checker</a>
         <span class="year year-2009" title="year">2009</span>
       </li>
       <li>
-        <a href="http://kangax.github.io/cft">Common Feature Tests</a>
+        <a href="https://kangax.github.io/cft/">Common Feature Tests</a>
         (
-          <a href="http://kangax.github.io/cft/style.html"><code>getStyleProperty</code> tests</a>,
-          <a href="http://kangax.github.io/iseventsupported/"><code>isEventSupported</code> tests</a>
+          <a href="https://kangax.github.io/cft/style.html"><code>getStyleProperty</code> tests</a>,
+          <a href="https://kangax.github.io/iseventsupported/"><code>isEventSupported</code> tests</a>
         )
         <span class="year year-2008" title="year">2008</span>
       </li>
       <li>
-        <a href="http://kangax.github.io/proto.menu" class="proto-menu">Proto.Menu</a>
+        <a href="https://kangax.github.io/proto.menu/" class="proto-menu">Proto.Menu</a>
         <span class="year year-2007" title="year">2007</span>
       </li>
     </ul>


### PR DESCRIPTION
I updated the GitHub.io urls to use HTTPS where possible.
Unfortunately, the compat-table websites have a Gratipay button, which currently does not work when you load the page over HTTPS.
I will take a loot at those pages, to see if and how it can be fixed.
